### PR TITLE
Make audit-docs language-agnostic with --root flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,11 @@ enum Commands {
         file: PathBuf,
     },
     /// Audit instruction files against the codebase
-    AuditDocs,
+    AuditDocs {
+        /// Project root directory (auto-detected if omitted)
+        #[arg(long)]
+        root: Option<PathBuf>,
+    },
 }
 
 fn main() -> anyhow::Result<()> {
@@ -90,6 +94,6 @@ fn main() -> anyhow::Result<()> {
         Commands::Diff { file } => diff::run(&file),
         Commands::Reset { file } => reset::run(&file),
         Commands::Clean { file } => clean::run(&file),
-        Commands::AuditDocs => audit_docs::run(),
+        Commands::AuditDocs { root } => audit_docs::run(root.as_deref()),
     }
 }

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -47,15 +47,15 @@ fn test_cli_audit_docs_subcommand() {
 }
 
 #[test]
-fn test_cli_audit_docs_in_tempdir_no_cargo_toml() {
+fn test_cli_audit_docs_in_tempdir_no_project_marker() {
     let tmp = tempfile::TempDir::new().unwrap();
     let mut cmd = agent_doc_cmd();
     cmd.current_dir(tmp.path());
     cmd.arg("audit-docs");
-    // Should fail because no Cargo.toml found
+    // Should succeed with a warning, falling back to CWD
     cmd.assert()
-        .failure()
-        .stderr(predicate::str::contains("could not find Cargo.toml"));
+        .success()
+        .stderr(predicate::str::contains("no project root marker found"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Replace Cargo.toml-only root detection with 3-pass strategy (project markers → .git → CWD fallback)
- Scan 28 file extensions across 6 source dirs instead of .rs only
- Add --root CLI flag to override auto-detection

## Test plan
- [x] 78 tests passing (cargo test)
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)