### PR TITLE
upgrade: GitHub Releases self-update

### DIFF
--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -2,11 +2,13 @@ use anyhow::Result;
 use serde_json::Value;
 use std::fs;
 use std::path::PathBuf;
+use std::io::Read as _;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const CRATE_NAME: &str = env!("CARGO_PKG_NAME");
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 const CACHE_TTL_SECS: u64 = 24 * 60 * 60; // 24 hours
+const GITHUB_REPO: &str = "btakita/agent-doc";
 
 /// Called on startup to print a warning if a newer version is available.
 /// Silently returns on any error.
@@ -19,48 +21,170 @@ pub fn warn_if_outdated() {
     }
 }
 
+/// Detect the current platform target triple.
+fn detect_target() -> Option<String> {
+    let os = if cfg!(target_os = "linux") {
+        "unknown-linux-gnu"
+    } else if cfg!(target_os = "macos") {
+        "apple-darwin"
+    } else {
+        return None;
+    };
+
+    let arch = if cfg!(target_arch = "x86_64") {
+        "x86_64"
+    } else if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else {
+        return None;
+    };
+
+    Some(format!("{arch}-{os}"))
+}
+
+/// Try to upgrade by downloading from GitHub Releases.
+/// Returns true if successful.
+fn try_github_release_upgrade(version: &str) -> bool {
+    let target = match detect_target() {
+        Some(t) => t,
+        None => return false,
+    };
+
+    let exe_path = match std::env::current_exe().and_then(|p| p.canonicalize()) {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+
+    let archive_name = format!("{CRATE_NAME}-{target}.tar.gz");
+    let url = format!(
+        "https://github.com/{GITHUB_REPO}/releases/download/v{version}/{archive_name}"
+    );
+
+    eprintln!("Downloading from GitHub Releases...");
+    eprintln!("  {url}");
+
+    let exe_dir = match exe_path.parent() {
+        Some(d) => d,
+        None => return false,
+    };
+
+    let tmp_archive = exe_dir.join(format!(".{CRATE_NAME}-upgrade.tar.gz"));
+    let tmp_binary = exe_dir.join(format!(".{CRATE_NAME}-upgrade"));
+
+    let agent = ureq::AgentBuilder::new()
+        .timeout_read(std::time::Duration::from_secs(30))
+        .timeout_write(std::time::Duration::from_secs(10))
+        .build();
+
+    let resp = match agent.get(&url).call() {
+        Ok(r) => r,
+        Err(_) => return false,
+    };
+
+    let mut archive_bytes = Vec::new();
+    if resp.into_reader().read_to_end(&mut archive_bytes).is_err() {
+        return false;
+    }
+
+    if std::fs::write(&tmp_archive, &archive_bytes).is_err() {
+        return false;
+    }
+
+    let tar_status = std::process::Command::new("tar")
+        .args(["xzf"])
+        .arg(&tmp_archive)
+        .arg("-C")
+        .arg(exe_dir)
+        .arg("--transform")
+        .arg(format!("s/{CRATE_NAME}/.{CRATE_NAME}-upgrade/"))
+        .status();
+
+    let _ = std::fs::remove_file(&tmp_archive);
+
+    let extracted_ok = matches!(tar_status, Ok(s) if s.success());
+    if !extracted_ok {
+        let _ = std::fs::remove_file(&tmp_binary);
+        return false;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&tmp_binary, std::fs::Permissions::from_mode(0o755));
+    }
+
+    if std::fs::rename(&tmp_binary, &exe_path).is_err() {
+        if std::fs::copy(&tmp_binary, &exe_path).is_err() {
+            let _ = std::fs::remove_file(&tmp_binary);
+            return false;
+        }
+        let _ = std::fs::remove_file(&tmp_binary);
+    }
+
+    true
+}
+
 /// The `upgrade` subcommand handler.
 pub fn run() -> Result<()> {
     eprintln!("Checking for updates...");
-    match check_for_update() {
-        Some(latest) => {
-            eprintln!(
-                "New version available: v{} (current: v{})",
-                latest, CURRENT_VERSION
-            );
-            eprintln!("Attempting upgrade via cargo install...");
-            let status = std::process::Command::new("cargo")
-                .args(["install", CRATE_NAME])
-                .status();
-            match status {
-                Ok(s) if s.success() => {
-                    eprintln!("Successfully upgraded to v{}.", latest);
-                    return Ok(());
-                }
-                _ => {
-                    eprintln!("cargo install failed. Trying pip install --upgrade...");
-                }
-            }
-            let status = std::process::Command::new("pip")
-                .args(["install", "--upgrade", CRATE_NAME])
-                .status();
-            match status {
-                Ok(s) if s.success() => {
-                    eprintln!("Successfully upgraded to v{} via pip.", latest);
-                }
-                _ => {
-                    eprintln!(
-                        "Automatic upgrade failed. Please upgrade manually:\n  \
-                         cargo install {} --force\n  or\n  pip install --upgrade {}",
-                        CRATE_NAME, CRATE_NAME
-                    );
-                }
-            }
-        }
+
+    let latest = match fetch_latest_version(CRATE_NAME) {
+        Some(v) => v,
         None => {
-            eprintln!("You are running the latest version (v{}).", CURRENT_VERSION);
+            eprintln!("Could not determine the latest version from crates.io.");
+            return Ok(());
+        }
+    };
+
+    if !version_is_newer(&latest, CURRENT_VERSION) {
+        eprintln!("You are already on the latest version (v{CURRENT_VERSION}).");
+        return Ok(());
+    }
+
+    eprintln!("New version available: v{latest} (current: v{CURRENT_VERSION})");
+
+    // Strategy 1: GitHub Releases binary download
+    if try_github_release_upgrade(&latest) {
+        eprintln!("Successfully upgraded to v{latest} via GitHub Releases.");
+        return Ok(());
+    }
+
+    // Strategy 2: cargo install
+    eprintln!("Attempting: cargo install {CRATE_NAME}");
+    let cargo_status = std::process::Command::new("cargo")
+        .args(["install", CRATE_NAME])
+        .status();
+
+    if let Ok(status) = cargo_status {
+        if status.success() {
+            eprintln!("Successfully upgraded to v{latest} via cargo.");
+            return Ok(());
         }
     }
+
+    // Strategy 3: pip install
+    eprintln!("cargo install failed, trying: pip install --upgrade {CRATE_NAME}");
+    let pip_status = std::process::Command::new("pip")
+        .args(["install", "--upgrade", CRATE_NAME])
+        .status();
+
+    if let Ok(status) = pip_status {
+        if status.success() {
+            eprintln!("Successfully upgraded to v{latest} via pip.");
+            return Ok(());
+        }
+    }
+
+    // Manual instructions
+    eprintln!(
+        "\nAutomatic upgrade failed. You can upgrade manually:\n\
+         \n  curl -sSf https://raw.githubusercontent.com/{GITHUB_REPO}/main/install.sh | sh\n\
+         \nor:\n\
+         \n  cargo install {CRATE_NAME}\n\
+         \nor:\n\
+         \n  pip install --upgrade {CRATE_NAME}\n"
+    );
+
     Ok(())
 }
 
@@ -246,5 +370,30 @@ mod tests {
         let parsed: Value = serde_json::from_str(&content).unwrap();
         assert_eq!(parsed["version"].as_str().unwrap(), "1.2.3");
         assert_eq!(parsed["timestamp"].as_u64().unwrap(), now);
+    }
+
+    #[test]
+    fn test_detect_target() {
+        let target = detect_target();
+        assert!(target.is_some(), "should detect current platform");
+        let t = target.unwrap();
+        assert!(t.contains('-'), "target should contain a dash");
+        assert!(
+            t.ends_with("unknown-linux-gnu") || t.ends_with("apple-darwin"),
+            "unexpected target: {t}"
+        );
+    }
+
+    #[test]
+    fn test_github_release_url_format() {
+        let version = "1.2.3";
+        let target = detect_target().unwrap();
+        let archive = format!("{}-{}.tar.gz", CRATE_NAME, target);
+        let url = format!(
+            "https://github.com/{}/releases/download/v{}/{}",
+            GITHUB_REPO, version, archive
+        );
+        assert!(url.starts_with("https://github.com/btakita/agent-doc/releases/download/v1.2.3/"));
+        assert!(url.ends_with(".tar.gz"));
     }
 }


### PR DESCRIPTION
## Summary
- `agent-doc upgrade` now tries GitHub Releases binary download first (same logic as install.sh)
- Fallback chain: GitHub Releases → cargo install → pip install → manual instructions
- Added `detect_target()` for platform detection and `try_github_release_upgrade()` for binary download + replace
- 2 new tests (detect_target, URL format). 90 total tests passing.

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — 90 tests passing
- [x] New tests verify platform detection and URL construction

🤖 Generated with [Claude Code](https://claude.com/claude-code)