### PR TITLE
v0.4.1: SKILL.md updates + PromptPanel overlay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-doc"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-doc"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Interactive document sessions with AI agents"
 license = "MIT"

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,12 @@ agent-doc is alpha software. Expect breaking changes between minor versions.
 
 Use `BREAKING CHANGE:` prefix in version entries to flag incompatible changes.
 
+## 0.4.1
+
+- **SKILL.md: comment stripping for diff**: Strip HTML comments (`<!-- ... -->`) and link reference comments (`[//]: # (...)`) before comparing snapshot vs current content. Comments are a user scratchpad and no longer trigger agent responses.
+- **SKILL.md: auto-update check**: New `agent-doc-version` frontmatter field enables pre-flight version comparison. If the installed binary is newer, `agent-doc skill install` runs automatically before proceeding.
+- **PromptPanel: JDialog to JLayeredPane overlay**: Replace `JDialog` popup with a `JLayeredPane` overlay in the JetBrains plugin, eliminating window-manager popup leaks.
+
 ## 0.4.0
 
 - **`agent-doc claim <file>`**: New subcommand — claim a document for the current tmux pane. Reads session UUID from frontmatter + `$TMUX_PANE`, updates `sessions.json`. Last-call-wins semantics. Also invokable as `/agent-doc claim <file>` via the Claude Code skill.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "agent-doc"
-version = "0.4.0"
+version = "0.4.1"
 description = "Interactive document sessions with AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- **SKILL.md: comment stripping for diff** — strip HTML comments (`<!-- ... -->`) and link reference comments (`[//]: # (...)`) before comparing snapshot vs current content. Comments are a user scratchpad and no longer trigger agent responses.
- **SKILL.md: auto-update check** — new `agent-doc-version` frontmatter field enables pre-flight version comparison. If the installed binary is newer, `agent-doc skill install` runs automatically before proceeding.
- **PromptPanel: JDialog to JLayeredPane overlay** — replace `JDialog` popup with a `JLayeredPane` overlay in the JetBrains plugin, eliminating window-manager popup leaks.
- Version bump 0.4.0 → 0.4.1 in `Cargo.toml`, `pyproject.toml`, and SKILL.md frontmatter.

## Test plan

- [x] `cargo test` — 93 tests pass (72 unit + 21 integration)
- [x] `cargo clippy -- -D warnings` — zero warnings
- [ ] Manual: verify SKILL.md comment stripping behavior in a live session
- [ ] Manual: verify auto-update triggers when binary is newer than frontmatter version

🤖 Generated with [Claude Code](https://claude.com/claude-code)