### PR TITLE
v0.4.2: SPECS.md gaps, flaky test fix, docs update

### DIFF
--- a/.claude/skills/agent-doc/SKILL.md
+++ b/.claude/skills/agent-doc/SKILL.md
@@ -2,7 +2,7 @@
 description: Submit a session document to an AI agent and append the response
 user-invocable: true
 argument-hint: "<file>"
-agent-doc-version: "0.4.1"
+agent-doc-version: "0.4.2"
 ---
 
 # agent-doc submit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,11 +28,15 @@ src/
   clean.rs          # Squash git history
   frontmatter.rs    # YAML frontmatter parse/write
   snapshot.rs       # Snapshot path/read/write
-  git.rs            # Commit, branch, squash
+  git.rs            # Commit, branch, squash (includes `commit` subcommand)
   config.rs         # Global config (~/.config/agent-doc/config.toml)
   sessions.rs       # Session registry (sessions.json) + Tmux struct
   route.rs          # Route /agent-doc commands to correct tmux pane
   start.rs          # Start Claude session inside tmux pane
+  claim.rs          # Claim document for current tmux pane
+  prompt.rs         # Detect permission prompts from Claude Code sessions
+  skill.rs          # Manage bundled SKILL.md (install/check)
+  upgrade.rs        # Self-update via crates.io / GitHub Releases
   agent/
     mod.rs          # Agent trait
     claude.rs       # Claude backend

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-doc"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-doc"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "Interactive document sessions with AI agents"
 license = "MIT"

--- a/SKILL.md
+++ b/SKILL.md
@@ -2,7 +2,7 @@
 description: Submit a session document to an AI agent and append the response
 user-invocable: true
 argument-hint: "<file>"
-agent-doc-version: "0.4.1"
+agent-doc-version: "0.4.2"
 ---
 
 # agent-doc submit

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,12 @@ agent-doc is alpha software. Expect breaking changes between minor versions.
 
 Use `BREAKING CHANGE:` prefix in version entries to flag incompatible changes.
 
+## 0.4.2
+
+- **SPECS.md gaps filled**: Document comment stripping as skill-level behavior (§4), `--root DIR` flag for audit-docs (§7.6), `agent-doc-version` frontmatter field for auto-update detection (§7.12), and startup version check (`warn_if_outdated`).
+- **Flaky test fix**: Skill tests no longer use `std::env::set_current_dir`. Refactored `install`/`check` to accept an explicit root path (`install_at`/`check_at`), eliminating CWD races in parallel test execution.
+- **CLAUDE.md module layout updated**: Added `claim.rs`, `prompt.rs`, `skill.rs`, `upgrade.rs` to the documented module layout.
+
 ## 0.4.1
 
 - **SKILL.md: comment stripping for diff**: Strip HTML comments (`<!-- ... -->`) and link reference comments (`[//]: # (...)`) before comparing snapshot vs current content. Comments are a user scratchpad and no longer trigger agent responses.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "agent-doc"
-version = "0.4.1"
+version = "0.4.2"
 description = "Interactive document sessions with AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- **SPECS.md gaps filled**: Document comment stripping as skill-level behavior (§4), `--root DIR` flag for audit-docs (§7.6), `agent-doc-version` frontmatter field for auto-update detection (§7.12), and startup version check (`warn_if_outdated`)
- **Flaky test fix**: Skill tests no longer use `std::env::set_current_dir`. Refactored `install`/`check` to accept an explicit root path (`install_at`/`check_at`), eliminating CWD races in parallel test execution
- **CLAUDE.md module layout updated**: Added `claim.rs`, `prompt.rs`, `skill.rs`, `upgrade.rs` to the documented module layout
- **Version bump**: 0.4.1 → 0.4.2 in Cargo.toml, pyproject.toml, SKILL.md

## Test plan
- [x] `cargo test` — 93 tests pass (72 unit + 21 integration)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `make precommit` (clippy + test + audit-docs) — all green
- [x] Previously-flaky `skill::tests::install_overwrites_outdated` now uses tempdir with explicit path

🤖 Generated with [Claude Code](https://claude.com/claude-code)