### PR TITLE
feat: claim notifications, plugin popup actions, resync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-doc"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-doc"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "Interactive document sessions with AI agents"
 license = "MIT"

--- a/SKILL.md
+++ b/SKILL.md
@@ -2,7 +2,7 @@
 description: Submit a session document to an AI agent and append the response
 user-invocable: true
 argument-hint: "<file>"
-agent-doc-version: "0.4.3"
+agent-doc-version: "0.5.2"
 ---
 
 # agent-doc submit
@@ -35,6 +35,8 @@ Arguments: `FILE` — path to the session document (e.g., `plan.md`)
 **Detect claim:** If the first argument is `claim`, run `agent-doc claim <FILE>` via Bash and stop. Do not proceed with the document session workflow. Print the output to confirm the claim.
 
 **Auto-update skill:** Run `agent-doc --version` and compare against the `agent-doc-version` in this file's frontmatter. If the binary version is newer, run `agent-doc skill install` to update this SKILL.md, then continue with the updated instructions. If `agent-doc` is not installed or the version matches, skip this step.
+
+**Check claims log:** Read `.agent-doc/claims.log` (if it exists). Print each line to the console as a record of IDE-triggered claims. Then truncate the file (write empty string). This gives a permanent record in the Claude session of claims made from the editor plugin.
 
 ### 1. Read the document and snapshot
 

--- a/editors/jetbrains/src/main/kotlin/com/github/btakita/agentdoc/AgentDocActionPromoter.kt
+++ b/editors/jetbrains/src/main/kotlin/com/github/btakita/agentdoc/AgentDocActionPromoter.kt
@@ -1,0 +1,24 @@
+package com.github.btakita.agentdoc
+
+import com.intellij.openapi.actionSystem.ActionPromoter
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.DataContext
+
+/**
+ * Promotes AgentDocPopupAction over the built-in ShowIntentionActions
+ * when Alt+Enter is pressed in a .md file. This prevents a disambiguation
+ * dialog when both actions are bound to the same shortcut.
+ */
+class AgentDocActionPromoter : ActionPromoter {
+    override fun promote(
+        actions: List<AnAction>,
+        context: DataContext
+    ): List<AnAction> {
+        val file = CommonDataKeys.VIRTUAL_FILE.getData(context)
+        if (file?.extension?.lowercase() == "md") {
+            return actions.sortedByDescending { it is AgentDocPopupAction }
+        }
+        return emptyList()
+    }
+}

--- a/editors/jetbrains/src/main/kotlin/com/github/btakita/agentdoc/AgentDocPopupAction.kt
+++ b/editors/jetbrains/src/main/kotlin/com/github/btakita/agentdoc/AgentDocPopupAction.kt
@@ -1,0 +1,44 @@
+package com.github.btakita.agentdoc
+
+import com.intellij.openapi.actionSystem.*
+import com.intellij.openapi.ui.popup.JBPopupFactory
+
+/**
+ * Shows a popup menu with Agent Doc commands when Alt+Enter is pressed in a .md file.
+ * This replaces IntentionAction-based registration which doesn't reliably activate
+ * for Markdown files (ShowIntentionsPass language filtering + DaemonCodeAnalyzer issues).
+ */
+class AgentDocPopupAction : AnAction() {
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val editor = e.getData(CommonDataKeys.EDITOR) ?: return
+
+        val group = DefaultActionGroup().apply {
+            add(ActionManager.getInstance().getAction("AgentDoc.Submit"))
+            add(ActionManager.getInstance().getAction("AgentDoc.Claim"))
+            addSeparator()
+            add(ActionManager.getInstance().getAction("AgentDoc.SyncLayout"))
+        }
+
+        val popup = JBPopupFactory.getInstance()
+            .createActionGroupPopup(
+                "Agent Doc",
+                group,
+                e.dataContext,
+                JBPopupFactory.ActionSelectionAid.NUMBERING,
+                true
+            )
+
+        popup.showInBestPositionFor(editor)
+    }
+
+    override fun update(e: AnActionEvent) {
+        val file = e.getData(CommonDataKeys.VIRTUAL_FILE)
+        e.presentation.isEnabledAndVisible =
+            file != null && file.extension?.lowercase() == "md"
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return ActionUpdateThread.BGT
+    }
+}

--- a/editors/jetbrains/src/main/kotlin/com/github/btakita/agentdoc/ClaimAction.kt
+++ b/editors/jetbrains/src/main/kotlin/com/github/btakita/agentdoc/ClaimAction.kt
@@ -1,0 +1,51 @@
+package com.github.btakita.agentdoc
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+
+/**
+ * Action that claims the selected .md file for the currently active tmux pane.
+ *
+ * Triggered by Ctrl+Shift+Alt+C (configurable in Keymap settings).
+ * Runs `agent-doc claim <relative-path>` which binds the file's session
+ * to whichever tmux pane is currently focused, then sets the pane title.
+ * After claiming, triggers a layout sync so the pane joins the layout window.
+ */
+class ClaimAction : AnAction() {
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val file = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
+        val basePath = project.basePath ?: return
+
+        val relativePath = TerminalUtil.relativePath(project, file)
+        val agentDoc = TerminalUtil.resolveAgentDoc()
+
+        Thread {
+            try {
+                val process = ProcessBuilder(agentDoc, "claim", relativePath)
+                    .directory(java.io.File(basePath))
+                    .redirectErrorStream(true)
+                    .start()
+                val output = process.inputStream.bufferedReader().readText().trim()
+                val exitCode = process.waitFor()
+                if (exitCode == 0) {
+                    TerminalUtil.notifyInfo(project, output.ifEmpty { "Claimed $relativePath" })
+                    // Re-sync layout so the claimed pane joins the layout window
+                    SyncLayoutAction.syncLayout(project, notify = false)
+                } else {
+                    TerminalUtil.notifyError(project, "Claim failed (exit $exitCode):\n$output")
+                }
+            } catch (ex: Exception) {
+                TerminalUtil.notifyError(project, "Failed to run agent-doc claim: ${ex.message}")
+            }
+        }.start()
+    }
+
+    override fun update(e: AnActionEvent) {
+        val file = e.getData(CommonDataKeys.VIRTUAL_FILE)
+        e.presentation.isEnabledAndVisible =
+            file != null && file.extension?.lowercase() == "md"
+    }
+}

--- a/editors/jetbrains/src/main/kotlin/com/github/btakita/agentdoc/SyncLayoutAction.kt
+++ b/editors/jetbrains/src/main/kotlin/com/github/btakita/agentdoc/SyncLayoutAction.kt
@@ -1,0 +1,111 @@
+package com.github.btakita.agentdoc
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
+import com.intellij.openapi.ui.Splitter
+import java.awt.Component
+
+/**
+ * Manually re-syncs the tmux pane layout to match the current IDE editor split.
+ *
+ * Triggered by Ctrl+Shift+Alt+L or via the Alt+Enter popup menu.
+ * Runs immediately (no debounce) and clears the dedup cache so
+ * automatic sync picks up subsequent changes.
+ */
+class SyncLayoutAction : AnAction() {
+
+    companion object {
+        /**
+         * Syncs tmux layout to match the IDE editor split. Can be called from
+         * any action (e.g. ClaimAction calls this after claiming).
+         * Runs on a background thread — safe to call from EDT.
+         */
+        fun syncLayout(project: com.intellij.openapi.project.Project, notify: Boolean = true) {
+            val basePath = project.basePath ?: return
+
+            val manager = FileEditorManager.getInstance(project)
+            val visibleMdFiles = manager.selectedFiles
+                .filter { it.name.endsWith(".md") }
+                .map { TerminalUtil.relativePath(project, it) }
+                .distinct()
+
+            if (visibleMdFiles.isEmpty()) {
+                if (notify) TerminalUtil.notifyInfo(project, "No .md files open")
+                return
+            }
+
+            val split = detectSplitOrientation(project)
+            EditorTabSyncListener.clearLastFileSet()
+
+            Thread {
+                try {
+                    val agentDoc = TerminalUtil.resolveAgentDoc()
+                    val cmd = if (visibleMdFiles.size == 1) {
+                        listOf(agentDoc, "focus", visibleMdFiles[0])
+                    } else {
+                        val splitFlag = if (split == "v") "v" else "h"
+                        listOf(agentDoc, "layout") + visibleMdFiles + listOf("--split", splitFlag)
+                    }
+                    val process = ProcessBuilder(cmd)
+                        .directory(java.io.File(basePath))
+                        .redirectErrorStream(true)
+                        .start()
+                    val output = process.inputStream.bufferedReader().readText().trim()
+                    val exitCode = process.waitFor()
+                    if (notify) {
+                        if (exitCode == 0) {
+                            TerminalUtil.notifyInfo(project, output.ifEmpty { "Layout synced" })
+                        } else {
+                            TerminalUtil.notifyError(project, "Sync failed (exit $exitCode):\n$output")
+                        }
+                    }
+                } catch (ex: Exception) {
+                    if (notify) TerminalUtil.notifyError(project, "Failed to sync layout: ${ex.message}")
+                }
+            }.start()
+        }
+
+        private fun detectSplitOrientation(project: com.intellij.openapi.project.Project): String {
+            try {
+                val managerEx = FileEditorManagerEx.getInstanceEx(project)
+                val splitters = managerEx.splitters
+                val root = (splitters as? java.awt.Container) ?: return "h"
+                return findSplitterOrientation(root) ?: "h"
+            } catch (_: Exception) {
+                return "h"
+            }
+        }
+
+        private fun findSplitterOrientation(component: Component): String? {
+            if (component is Splitter) {
+                return if (component.isVertical) "v" else "h"
+            }
+            if (component is java.awt.Container) {
+                for (child in component.components) {
+                    val result = findSplitterOrientation(child)
+                    if (result != null) return result
+                }
+            }
+            return null
+        }
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        syncLayout(project)
+    }
+
+    override fun update(e: AnActionEvent) {
+        val file = e.getData(CommonDataKeys.VIRTUAL_FILE)
+        e.presentation.isEnabledAndVisible =
+            file != null && file.extension?.lowercase() == "md"
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return ActionUpdateThread.BGT
+    }
+}

--- a/editors/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/editors/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -17,6 +17,8 @@
         <notificationGroup id="Agent Doc"
                            displayType="BALLOON"
                            isLogByDefault="true"/>
+        <actionPromoter
+            implementation="com.github.btakita.agentdoc.AgentDocActionPromoter"/>
     </extensions>
 
     <projectListeners>
@@ -27,6 +29,12 @@
     </projectListeners>
 
     <actions>
+        <action id="AgentDoc.Popup"
+                class="com.github.btakita.agentdoc.AgentDocPopupAction"
+                text="Agent Doc Actions"
+                description="Show Agent Doc actions for the current markdown file">
+            <keyboard-shortcut first-keystroke="alt ENTER" keymap="$default"/>
+        </action>
         <action id="AgentDoc.Submit"
                 class="com.github.btakita.agentdoc.SubmitAction"
                 text="Submit to Agent Doc"
@@ -35,6 +43,23 @@
             <add-to-group group-id="ToolsMenu" anchor="last"/>
             <add-to-group group-id="EditorPopupMenu" anchor="last"/>
             <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
+        </action>
+        <action id="AgentDoc.Claim"
+                class="com.github.btakita.agentdoc.ClaimAction"
+                text="Claim for Tmux Pane"
+                description="Claim this document for the currently active tmux pane">
+            <keyboard-shortcut first-keystroke="ctrl shift alt C" keymap="$default"/>
+            <add-to-group group-id="ToolsMenu" anchor="last"/>
+            <add-to-group group-id="EditorPopupMenu" anchor="last"/>
+            <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
+        </action>
+        <action id="AgentDoc.SyncLayout"
+                class="com.github.btakita.agentdoc.SyncLayoutAction"
+                text="Sync Tmux Layout"
+                description="Re-sync tmux pane layout to match the current editor split">
+            <keyboard-shortcut first-keystroke="ctrl shift alt L" keymap="$default"/>
+            <add-to-group group-id="ToolsMenu" anchor="last"/>
+            <add-to-group group-id="EditorPopupMenu" anchor="last"/>
         </action>
     </actions>
 </idea-plugin>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "agent-doc"
-version = "0.5.1"
+version = "0.5.2"
 description = "Interactive document sessions with AI agents"
 readme = "README.md"
 license = "MIT"

--- a/src/claim.rs
+++ b/src/claim.rs
@@ -7,6 +7,7 @@
 //! plugin (and `agent-doc route`) to send commands to the correct pane.
 
 use anyhow::{Context, Result};
+use std::io::Write;
 use std::path::Path;
 
 use crate::{frontmatter, sessions};
@@ -14,11 +15,6 @@ use crate::{frontmatter, sessions};
 pub fn run(file: &Path) -> Result<()> {
     if !file.exists() {
         anyhow::bail!("file not found: {}", file.display());
-    }
-
-    // Must be inside tmux
-    if !sessions::in_tmux() {
-        anyhow::bail!("not running inside tmux — TMUX_PANE is not set");
     }
 
     // Ensure session UUID exists in frontmatter
@@ -36,6 +32,27 @@ pub fn run(file: &Path) -> Result<()> {
     // Register session → pane
     let file_str = file.to_string_lossy();
     sessions::register(&session_id, &pane_id, &file_str)?;
+
+    // Show a brief notification on the target pane
+    let msg = format!("Claimed {} (pane {})", file_str, pane_id);
+    let _ = std::process::Command::new("tmux")
+        .args(["display-message", "-t", &pane_id, "-d", "3000", &msg])
+        .status();
+
+    // Append to claims log so the skill can display it on next invocation
+    let log_line = format!("Claimed {} for pane {}\n", file_str, pane_id);
+    let log_path = std::path::Path::new(".agent-doc/claims.log");
+    if let Some(parent) = log_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)
+    {
+        let _ = write!(f, "{}", log_line);
+    }
+
     eprintln!(
         "Claimed {} for pane {} (session {})",
         file.display(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod init;
 mod layout;
 mod prompt;
 mod reset;
+mod resync;
 mod route;
 mod sessions;
 mod skill;
@@ -127,6 +128,8 @@ enum Commands {
         #[arg(long, short, default_value = "h")]
         split: String,
     },
+    /// Validate sessions.json against live tmux panes, remove stale entries
+    Resync,
     /// Manage the Claude Code skill definition
     Skill {
         #[command(subcommand)]
@@ -193,6 +196,7 @@ fn main() -> anyhow::Result<()> {
             let paths: Vec<&Path> = files.iter().map(|f| f.as_path()).collect();
             layout::run(&paths, split)
         }
+        Commands::Resync => resync::run(),
         Commands::Skill { command } => match command {
             SkillCommands::Install => skill::install(),
             SkillCommands::Check => skill::check(),

--- a/src/resync.rs
+++ b/src/resync.rs
@@ -1,0 +1,60 @@
+//! Resync — validate sessions.json against live tmux panes.
+//!
+//! Removes stale entries whose tmux panes no longer exist,
+//! and reports the current state of the registry.
+
+use anyhow::Result;
+
+use crate::sessions::{self, Tmux};
+
+pub fn run() -> Result<()> {
+    let tmux = Tmux::default_server();
+    let mut registry = sessions::load()?;
+    let before = registry.len();
+
+    // Partition into alive and dead entries.
+    let mut dead: Vec<(String, String, String)> = Vec::new();
+    registry.retain(|session_id, entry| {
+        let alive = tmux.pane_alive(&entry.pane);
+        if !alive {
+            dead.push((
+                session_id.clone(),
+                entry.pane.clone(),
+                entry.file.clone(),
+            ));
+        }
+        alive
+    });
+
+    let removed = before - registry.len();
+
+    if removed > 0 {
+        sessions::save(&registry)?;
+        eprintln!("Removed {} stale session(s):", removed);
+        for (session_id, pane, file) in &dead {
+            let label = if file.is_empty() {
+                session_id.as_str()
+            } else {
+                file.as_str()
+            };
+            eprintln!("  {} (pane {} dead)", label, pane);
+        }
+    } else {
+        eprintln!("All {} session(s) have live panes.", registry.len());
+    }
+
+    // Show current state.
+    if !registry.is_empty() {
+        eprintln!("\nActive sessions:");
+        for (session_id, entry) in &registry {
+            let label = if entry.file.is_empty() {
+                session_id.as_str()
+            } else {
+                entry.file.as_str()
+            };
+            eprintln!("  {} → pane {}", label, entry.pane);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- **Claim notifications**: `tmux display-message` (3s overlay) for immediate feedback + `.agent-doc/claims.log` for deferred session records. SKILL.md reads/prints/truncates on next invocation.
- **Plugin popup actions**: Alt+Enter popup (Submit/Claim/Sync Layout) replacing failed IntentionAction approach. ActionPromoter prioritizes for .md files.
- **SyncLayoutAction**: Manual tmux layout sync (Ctrl+Shift+Alt+L). Shared static method used by ClaimAction after successful claim.
- **EditorTabSyncListener hardened**: 500ms debounce, concurrency guard, dedup tracking file set + active file.
- **`agent-doc resync`**: New subcommand to prune dead panes from sessions.json.
- **Layout fixes**: Focus active file's pane after layout, not anchor pane.

## Test plan

- [x] `make check` — 93 tests passing (72 unit + 21 integration)
- [ ] Verify claim from IDE shows display-message overlay
- [ ] Verify claims.log printed on next `/agent-doc` invocation
- [ ] Verify Alt+Enter popup appears for .md files in JetBrains
- [ ] Verify Sync Layout action works (Ctrl+Shift+Alt+L)

🤖 Generated with [Claude Code](https://claude.com/claude-code)