### PR TITLE
docs: v0.5.3 — bundled SKILL.md with absolute snapshot paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-doc"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-doc"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "Interactive document sessions with AI agents"
 license = "MIT"

--- a/SKILL.md
+++ b/SKILL.md
@@ -2,7 +2,7 @@
 description: Submit a session document to an AI agent and append the response
 user-invocable: true
 argument-hint: "<file>"
-agent-doc-version: "0.5.2"
+agent-doc-version: "0.5.3"
 ---
 
 # agent-doc submit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "agent-doc"
-version = "0.5.2"
+version = "0.5.3"
 description = "Interactive document sessions with AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump to v0.5.3 to bundle updated SKILL.md with CWD drift fix
- SKILL.md now includes absolute path requirement for snapshot operations
- Doc-only release — no code changes

## Test plan

- [x] `make check` — 93 tests pass, clippy clean
- [x] `audit-docs` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)