### PR TITLE
feat: positional claim, plugin improvements, editor SPECs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-doc"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 description = "Interactive document sessions with AI agents"
 license = "MIT"

--- a/editors/SPEC.md
+++ b/editors/SPEC.md
@@ -1,0 +1,57 @@
+# Editor Plugin Specification
+
+Common behavior required of all `agent-doc` editor plugins.
+
+## 1. Run (Submit)
+
+- **Trigger:** `Ctrl+Shift+Alt+A` (configurable)
+- **Behavior:** Save the active `.md` file, call `agent-doc route <relative-path>` from the project root.
+- **Feedback:** Inline hint near cursor (auto-dismissing). Error notifications persist.
+- **Availability:** Only enabled when a `.md` file is active.
+
+## 2. Claim for Tmux Pane
+
+- **Trigger:** `Ctrl+Shift+Alt+C` (configurable)
+- **Behavior:** Detect which editor split the file is in (left/right/top/bottom), call `agent-doc claim <relative-path> --position <pos>`. Falls back to no `--position` if split is not detected.
+- **Feedback:** Inline hint near cursor. After claiming, trigger a layout sync (silent).
+
+## 3. Sync Tmux Layout
+
+- **Trigger:** `Ctrl+Shift+Alt+L` (configurable)
+- **Behavior:** Collect all visible `.md` files, detect split orientation, call `agent-doc layout <files...> --split h|v` (or `agent-doc focus <file>` for single file).
+- **Feedback:** Inline hint near cursor.
+
+## 4. Tab-to-Pane Sync (Automatic)
+
+- **Trigger:** Editor tab selection changes.
+- **Behavior:** When the active `.md` file changes, call `agent-doc focus <file>`. When the visible file set changes, call `agent-doc layout`.
+- **Debounce:** 500ms. Skip if file set unchanged. Concurrency guard (one command at a time).
+
+## 5. Prompt Polling
+
+- **Trigger:** After a Run action, poll `agent-doc prompt --all` every 1.5s.
+- **Behavior:** Detect numbered-option permission prompts. Display a bottom-anchored panel with buttons for each option. Support keyboard selection (Alt+1..9, Alt+Esc toggle, Esc dismiss).
+- **Answer:** Call `agent-doc prompt --answer <N> <file>` when user selects an option.
+- **Auto-save:** Save tracked files before each poll cycle to capture user edits.
+
+## 6. Popup Menu
+
+- **Trigger:** `Alt+Enter` on a `.md` file.
+- **Behavior:** Show numbered popup with Run, Claim, Sync Layout actions.
+
+## 7. Notifications
+
+- **Success:** Lightweight inline hint near cursor (auto-dismissing, ~1-2 seconds).
+- **Error:** Persistent notification balloon. Errors never auto-dismiss.
+- **No temp files:** All diagnostic logging uses the IDE's built-in logger, not file I/O.
+
+## 8. File Filtering
+
+- All actions are only enabled/visible when a `.md` file is active or selected.
+- Non-`.md` files are ignored by tab sync and prompt polling.
+
+## 9. CLI Dependency
+
+- Plugins resolve `agent-doc` from: `~/bin/`, `~/.local/bin/`, `~/.cargo/bin/`, `/usr/local/bin/`, or `$PATH`.
+- All commands run from the project root directory.
+- Plugins are thin wrappers — business logic lives in the CLI.

--- a/editors/jetbrains/AGENTS.md
+++ b/editors/jetbrains/AGENTS.md
@@ -1,0 +1,34 @@
+# agent-doc JetBrains Plugin
+
+## Build
+
+Always build **both** unsigned and signed plugin zips:
+
+```bash
+cd agent-doc/editors/jetbrains
+./gradlew buildPlugin signPlugin
+```
+
+Output:
+- `build/distributions/agent-doc-jetbrains-0.1.0.zip` (unsigned)
+- `build/distributions/agent-doc-jetbrains-0.1.0-signed.zip` (signed)
+
+## Install
+
+IDEA → Settings → Plugins → gear icon → "Install Plugin from Disk..." → select the zip.
+
+If classes changed structurally (new imports, methods, fields): **uninstall first → restart → install → restart**. Reinstalling over an existing plugin may not replace cached bytecode.
+
+## Logging
+
+Uses `com.intellij.openapi.diagnostic.Logger`. No temp files.
+
+Enable debug output: IDEA → `Help > Diagnostic Tools > Debug Log Settings` → add `#com.github.btakita.agentdoc`. Output appears in `idea.log`.
+
+## Conventions
+
+- Plugin is a thin wrapper — business logic lives in the `agent-doc` CLI.
+- All CLI calls run from the project root directory.
+- Success feedback uses inline hints (`HintManager`), not balloon notifications.
+- Error feedback uses persistent balloon notifications.
+- `plugin.xml` action IDs are stable — only change `text` attributes for renames.

--- a/editors/jetbrains/CLAUDE.md
+++ b/editors/jetbrains/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/editors/jetbrains/SPEC.md
+++ b/editors/jetbrains/SPEC.md
@@ -1,0 +1,70 @@
+# JetBrains Plugin Specification
+
+Extends `editors/SPEC.md` with JetBrains-specific behavior.
+
+## Plugin Metadata
+
+- **ID:** `com.github.btakita.agent-doc`
+- **Name:** Agent Doc
+- **Restart:** Not required (`require-restart="false"`)
+
+## Implementation Details
+
+### Claim — Split Position Detection
+
+Two strategies for detecting the file's position in the editor split:
+
+1. **Splitter tree walk:** Get the `EDITOR` component from action context, walk the Swing `Splitter` tree to determine if it's in the first child (left/top) or second child (right/bottom).
+2. **Window index fallback:** If no EDITOR context (e.g., context menu), enumerate `FileEditorManagerEx.windows`, find which window contains the file, determine position from the Splitter tree or use window index + orientation as heuristic.
+
+### Prompt Panel
+
+- Rendered as a `JLayeredPane` overlay at `POPUP_LAYER` — no `JDialog` (avoids WM leaks and focus-loss dismissal).
+- Uses IDE editor font via `EditorColorsManager`.
+- `WrapLayout` for multi-row button overflow when labels are long.
+- Labels truncated to 80 characters with tooltip for full text.
+
+### Tab Sync Listener
+
+- Registered as `FileEditorManagerListener` in `plugin.xml`.
+- Split orientation detected by walking the Swing component tree for `Splitter` nodes.
+- Dedup cache (`lastFileSet` + `lastActiveFile`) prevents redundant CLI calls.
+
+### Auto-Save Before Poll
+
+- `PromptPoller` saves tracked files via `FileDocumentManager` before each poll cycle.
+- 3-way merge via `git merge-file` when both disk and editor have changed.
+
+### Action Promoter
+
+- `AgentDocActionPromoter` ensures `AgentDocPopupAction` (Alt+Enter) takes priority over the built-in `ShowIntentionActions`.
+
+### Logging
+
+- Uses `com.intellij.openapi.diagnostic.Logger` (IntelliJ platform logger).
+- Enable debug output: `Help > Diagnostic Tools > Debug Log Settings` → add `#com.github.btakita.agentdoc`.
+- Output appears in `idea.log`. No temp files.
+
+### Dynamic Lifecycle
+
+- `PluginLifecycleListener` handles `projectOpened`/`projectClosing`.
+- `disposeAll()` cleans up prompt panels and pollers on project close or plugin unload.
+
+## Keybindings
+
+| Action | Default Shortcut |
+|--------|-----------------|
+| Run | `Ctrl+Shift+Alt+A` |
+| Claim | `Ctrl+Shift+Alt+C` |
+| Sync Layout | `Ctrl+Shift+Alt+L` |
+| Popup Menu | `Alt+Enter` |
+| Prompt Select | `Alt+1..9` |
+| Prompt Toggle | `Alt+Esc` |
+| Prompt Dismiss | `Esc` |
+
+## Context Menu
+
+Run, Claim, and Sync Layout are available in:
+- Tools menu
+- Editor right-click context menu
+- Project view right-click context menu (Run and Claim only)

--- a/editors/jetbrains/src/main/kotlin/com/github/btakita/agentdoc/ClaimAction.kt
+++ b/editors/jetbrains/src/main/kotlin/com/github/btakita/agentdoc/ClaimAction.kt
@@ -3,16 +3,28 @@ package com.github.btakita.agentdoc
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
+import com.intellij.openapi.ui.Splitter
+import com.intellij.openapi.vfs.VirtualFile
+import java.awt.Component
 
 /**
- * Action that claims the selected .md file for the currently active tmux pane.
+ * Action that claims the selected .md file for the correct tmux pane
+ * based on its position in the editor split.
  *
  * Triggered by Ctrl+Shift+Alt+C (configurable in Keymap settings).
- * Runs `agent-doc claim <relative-path>` which binds the file's session
- * to whichever tmux pane is currently focused, then sets the pane title.
+ * Detects whether the file is in the left/right (or top/bottom) editor split
+ * and passes `--position` to `agent-doc claim` so the correct tmux pane
+ * is selected by coordinates rather than whichever pane is focused.
  * After claiming, triggers a layout sync so the pane joins the layout window.
  */
 class ClaimAction : AnAction() {
+
+    companion object {
+        private val LOG = Logger.getInstance(ClaimAction::class.java)
+    }
 
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
@@ -21,17 +33,25 @@ class ClaimAction : AnAction() {
 
         val relativePath = TerminalUtil.relativePath(project, file)
         val agentDoc = TerminalUtil.resolveAgentDoc()
+        val position = detectEditorPosition(e, file)
+
+        LOG.debug("claim $relativePath position=$position agentDoc=$agentDoc")
 
         Thread {
             try {
-                val process = ProcessBuilder(agentDoc, "claim", relativePath)
+                val cmd = mutableListOf(agentDoc, "claim", relativePath)
+                if (position != null) {
+                    cmd.addAll(listOf("--position", position))
+                }
+                LOG.debug("cmd: ${cmd.joinToString(" ")}")
+                val process = ProcessBuilder(cmd)
                     .directory(java.io.File(basePath))
                     .redirectErrorStream(true)
                     .start()
                 val output = process.inputStream.bufferedReader().readText().trim()
                 val exitCode = process.waitFor()
                 if (exitCode == 0) {
-                    TerminalUtil.notifyInfo(project, output.ifEmpty { "Claimed $relativePath" })
+                    TerminalUtil.showHint(project, output.ifEmpty { "Claimed $relativePath (pos=$position)" })
                     // Re-sync layout so the claimed pane joins the layout window
                     SyncLayoutAction.syncLayout(project, notify = false)
                 } else {
@@ -41,6 +61,133 @@ class ClaimAction : AnAction() {
                 TerminalUtil.notifyError(project, "Failed to run agent-doc claim: ${ex.message}")
             }
         }.start()
+    }
+
+    /**
+     * Detect the position of the current file in the editor split layout.
+     * Strategy:
+     * 1. Try to find the editor component in the Splitter tree (works when action
+     *    is triggered from an open editor with EDITOR context available)
+     * 2. Fall back to checking which split window contains the file (works from
+     *    context menu, file tree, etc.)
+     */
+    private fun detectEditorPosition(e: AnActionEvent, file: VirtualFile): String? {
+        val project = e.project ?: return null
+        try {
+            val managerEx = FileEditorManagerEx.getInstanceEx(project)
+            val splitters = managerEx.splitters
+            val root = (splitters as? java.awt.Container) ?: run {
+                LOG.debug("splitters not a Container: ${splitters?.javaClass?.name}")
+                return null
+            }
+
+            // Strategy 1: Use the EDITOR component from action context
+            val editor = e.getData(CommonDataKeys.EDITOR)
+            if (editor != null) {
+                val editorComponent = editor.component
+                LOG.debug("strategy1: editor component=${editorComponent.javaClass.name}")
+                val pos = findPositionInSplitter(root, editorComponent)
+                if (pos != null) {
+                    LOG.debug("strategy1: found position=$pos")
+                    return pos
+                }
+                LOG.debug("strategy1: position not found in splitter tree")
+            } else {
+                LOG.debug("strategy1: EDITOR is null")
+            }
+
+            // Strategy 2: Find which split window contains the target file
+            // by looking at the open files in each window/composite
+            val windows = managerEx.windows
+            LOG.debug("strategy2: ${windows.size} windows")
+            if (windows.size >= 2) {
+                // Find which window has our file
+                for ((idx, window) in windows.withIndex()) {
+                    val files = window.files
+                    LOG.debug("  window[$idx]: ${files.map { it.name }}")
+                    if (files.any { it.path == file.path }) {
+                        // Determine if this window's component is first or second in the splitter
+                        val windowComponent = (window as? Component)
+                        if (windowComponent != null) {
+                            val pos = findPositionInSplitter(root, windowComponent)
+                            if (pos != null) {
+                                LOG.debug("strategy2: window[$idx] position=$pos")
+                                return pos
+                            }
+                        }
+                        // Heuristic: first window = left/top, second = right/bottom
+                        val orientation = findSplitterOrientation(root)
+                        val pos = when {
+                            idx == 0 && orientation == "h" -> "left"
+                            idx == 0 && orientation == "v" -> "top"
+                            idx >= 1 && orientation == "h" -> "right"
+                            idx >= 1 && orientation == "v" -> "bottom"
+                            else -> null
+                        }
+                        LOG.debug("strategy2: heuristic idx=$idx orientation=$orientation -> $pos")
+                        return pos
+                    }
+                }
+            }
+
+            LOG.debug("no position detected")
+            return null
+        } catch (ex: Exception) {
+            LOG.debug("exception: ${ex.message}")
+            return null
+        }
+    }
+
+    /**
+     * Walk the component tree to find the Splitter containing the target component,
+     * then determine if the target is in the first or second child.
+     */
+    private fun findPositionInSplitter(component: Component, target: Component): String? {
+        if (component is Splitter) {
+            val firstChild = component.firstComponent
+            val secondChild = component.secondComponent
+            val isVertical = component.isVertical
+
+            if (firstChild != null && isDescendant(firstChild, target)) {
+                return if (isVertical) "top" else "left"
+            }
+            if (secondChild != null && isDescendant(secondChild, target)) {
+                return if (isVertical) "bottom" else "right"
+            }
+        }
+        if (component is java.awt.Container) {
+            for (child in component.components) {
+                val result = findPositionInSplitter(child, target)
+                if (result != null) return result
+            }
+        }
+        return null
+    }
+
+    private fun findSplitterOrientation(component: Component): String? {
+        if (component is Splitter) {
+            return if (component.isVertical) "v" else "h"
+        }
+        if (component is java.awt.Container) {
+            for (child in component.components) {
+                val result = findSplitterOrientation(child)
+                if (result != null) return result
+            }
+        }
+        return null
+    }
+
+    /**
+     * Check if target is a descendant of (or equal to) the container.
+     */
+    private fun isDescendant(container: Component, target: Component): Boolean {
+        if (container === target) return true
+        if (container is java.awt.Container) {
+            for (child in container.components) {
+                if (isDescendant(child, target)) return true
+            }
+        }
+        return false
     }
 
     override fun update(e: AnActionEvent) {

--- a/editors/jetbrains/src/main/kotlin/com/github/btakita/agentdoc/EditorTabSyncListener.kt
+++ b/editors/jetbrains/src/main/kotlin/com/github/btakita/agentdoc/EditorTabSyncListener.kt
@@ -1,5 +1,6 @@
 package com.github.btakita.agentdoc
 
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
@@ -31,7 +32,7 @@ class EditorTabSyncListener : FileEditorManagerListener {
         private val running = AtomicBoolean(false)
         @Volatile private var lastFileSet: List<String> = emptyList()
         @Volatile private var lastActiveFile: String = ""
-        private val LOG_FILE = java.io.File("/tmp/agent-doc-plugin.log")
+        private val LOG = Logger.getInstance(EditorTabSyncListener::class.java)
 
         /** Clear the dedup cache so the next automatic sync runs unconditionally. */
         fun clearLastFileSet() {
@@ -41,9 +42,7 @@ class EditorTabSyncListener : FileEditorManagerListener {
     }
 
     private fun log(msg: String) {
-        try {
-            LOG_FILE.appendText("${java.time.Instant.now()} $msg\n")
-        } catch (_: Exception) {}
+        LOG.debug(msg)
     }
 
     override fun selectionChanged(event: FileEditorManagerEvent) {

--- a/editors/jetbrains/src/main/kotlin/com/github/btakita/agentdoc/SyncLayoutAction.kt
+++ b/editors/jetbrains/src/main/kotlin/com/github/btakita/agentdoc/SyncLayoutAction.kt
@@ -34,7 +34,7 @@ class SyncLayoutAction : AnAction() {
                 .distinct()
 
             if (visibleMdFiles.isEmpty()) {
-                if (notify) TerminalUtil.notifyInfo(project, "No .md files open")
+                if (notify) TerminalUtil.showHint(project, "No .md files open")
                 return
             }
 
@@ -58,7 +58,7 @@ class SyncLayoutAction : AnAction() {
                     val exitCode = process.waitFor()
                     if (notify) {
                         if (exitCode == 0) {
-                            TerminalUtil.notifyInfo(project, output.ifEmpty { "Layout synced" })
+                            TerminalUtil.showHint(project, output.ifEmpty { "Layout synced" })
                         } else {
                             TerminalUtil.notifyError(project, "Sync failed (exit $exitCode):\n$output")
                         }

--- a/editors/jetbrains/src/main/kotlin/com/github/btakita/agentdoc/TerminalUtil.kt
+++ b/editors/jetbrains/src/main/kotlin/com/github/btakita/agentdoc/TerminalUtil.kt
@@ -69,7 +69,7 @@ object TerminalUtil {
         return "agent-doc"
     }
 
-    private fun showHint(project: Project, message: String) {
+    fun showHint(project: Project, message: String) {
         ApplicationManager.getApplication().invokeLater {
             val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return@invokeLater
             HintManager.getInstance().showInformationHint(editor, message)
@@ -89,10 +89,15 @@ object TerminalUtil {
 
     fun notifyInfo(project: Project, content: String) {
         try {
-            NotificationGroupManager.getInstance()
+            val notification = NotificationGroupManager.getInstance()
                 .getNotificationGroup("Agent Doc")
                 .createNotification(content, NotificationType.INFORMATION)
-                .notify(project)
+            notification.notify(project)
+            // Auto-expire after 3 seconds
+            Thread {
+                Thread.sleep(3000)
+                notification.expire()
+            }.start()
         } catch (_: Exception) {
             System.err.println("[agent-doc] $content")
         }

--- a/editors/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/editors/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -37,7 +37,7 @@
         </action>
         <action id="AgentDoc.Submit"
                 class="com.github.btakita.agentdoc.SubmitAction"
-                text="Submit to Agent Doc"
+                text="Run Agent Doc"
                 description="Route /agent-doc command to the correct Claude session via tmux">
             <keyboard-shortcut first-keystroke="ctrl shift alt A" keymap="$default"/>
             <add-to-group group-id="ToolsMenu" anchor="last"/>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "agent-doc"
-version = "0.5.3"
+version = "0.5.4"
 description = "Interactive document sessions with AI agents"
 readme = "README.md"
 license = "MIT"

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,9 @@ enum Commands {
     Claim {
         /// Path to the session document
         file: PathBuf,
+        /// Positional hint to select pane by position (left, right, top, bottom)
+        #[arg(long)]
+        position: Option<String>,
     },
     /// Focus the tmux pane for a session document
     Focus {
@@ -186,7 +189,7 @@ fn main() -> anyhow::Result<()> {
             }
         }
         Commands::Commit { file } => git::commit(&file),
-        Commands::Claim { file } => claim::run(&file),
+        Commands::Claim { file, position } => claim::run(&file, position.as_deref()),
         Commands::Focus { file } => focus::run(&file),
         Commands::Layout { files, split } => {
             let split = match split.as_str() {


### PR DESCRIPTION
## Summary
- `agent-doc claim --position left|right|top|bottom` for split-aware tmux pane claiming
- JetBrains plugin: Splitter tree walk detects editor split position, passes `--position` to CLI
- Plugin logging: `/tmp/agent-doc-plugin.log` → IntelliJ `Logger.debug()` (no temp files)
- Plugin UX: `notifyInfo` → `showHint` (inline hints), "Submit" → "Run", 3s auto-expire
- Claim auto-focuses the claimed pane via `select-pane`
- PID registration fix: `claim` stores pane's actual PID, not CLI's ephemeral PID
- New: `editors/SPEC.md`, `editors/jetbrains/SPEC.md`, `editors/jetbrains/AGENTS.md`

## Test plan
- [x] 93 tests pass (72 unit + 21 integration)
- [x] `--position left` → correct pane, `--position right` → correct pane
- [x] Plugin builds (unsigned + signed)
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)